### PR TITLE
Add event counters to output messages statistics

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 pgagroal was created by the following authors:
 
 Jesper Pedersen <jesper.pedersen@redhat.com>
+Henrique de Carvalho <decarv.henrique@gmail.com>

--- a/src/include/counter.h
+++ b/src/include/counter.h
@@ -26,37 +26,38 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PGPRTDBG_PROTOCOL_H
-#define PGPRTDBG_PROTOCOL_H
+#ifndef PGPRTDBG_COUNTER_H
+#define PGPRTDBG_COUNTER_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <inttypes.h>
 
-#include <pgprtdbg.h>
+#define MAX_NUMBER_OF_COUNTERS MAX_NUMBER_OF_CONNECTIONS
 
-#include <stdlib.h>
+/** @struct
+ * Holds collected events for one client.
+ */
+struct event_counter
+{
+   int client_number;
+   uint64_t rcvd_bytes;
+   uint64_t sent_bytes;
+   uint32_t rcvd_messages;
+   uint32_t sent_messages;
+};
+
+extern size_t event_counters_offset;
 
 /**
- * Decode a message from the client
- * @param from The from socket
- * @param to The to socket
- * @param msg The message
+ * Gets a new event_counter.
+ * @return Pointer to the next struct event_counter.
  */
-void
-pgprtdbg_client(int from, int to, struct message* msg, struct event_counter* counter);
+struct event_counter*
+pgprtdbg_counter_get(int client_number);
 
 /**
- * Decode a message from the server
- * @param from The from socket
- * @param to The to socket
- * @param msg The message
+ * Outputs the statistics for all counters.
  */
 void
-pgprtdbg_server(int from, int to, struct message* msg, struct event_counter* counter);
+pgprtdbg_counter_output_statistics(int client_count);
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif
+#endif //PGPRTDBG_COUNTER_H

--- a/src/include/pgprtdbg.h
+++ b/src/include/pgprtdbg.h
@@ -90,6 +90,8 @@ struct configuration
    FILE* file;               /**< The file */
    sem_t lock;               /**< The file lock */
 
+   char statistics_output[MISC_LENGTH];
+
    bool output_sockets;      /**< Output socket identifiers */
    bool save_traffic;        /**< Save the traffic in files */
 

--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -50,6 +50,7 @@ struct worker_io
    struct ev_io io;      /**< The libev base type */
    int client_fd;        /**< The client descriptor */
    int server_fd;        /**< The server descriptor */
+   struct event_counter* counter;
 };
 
 extern volatile int running;
@@ -58,9 +59,10 @@ extern volatile int exit_code;
 /**
  * Create a worker instance
  * @param fd The client descriptor
+ * @param client_number The number of the client, from 0 to MAX_NUMBER_OF_COUNTERS - 1
  */
 void
-pgprtdbg_worker(int fd);
+pgprtdbg_worker(int fd, int client_number);
 
 #ifdef __cplusplus
 }

--- a/src/libpgprtdbg/configuration.c
+++ b/src/libpgprtdbg/configuration.c
@@ -75,6 +75,8 @@ pgprtdbg_init_configuration(void)
 
    config->file = NULL;
 
+   *config->statistics_output = 0;
+
    atomic_init(&config->active_connections, 0);
 
    return 0;
@@ -343,6 +345,22 @@ pgprtdbg_read_configuration(char* filename)
                   if (!strcmp(section, "pgprtdbg"))
                   {
                      config->backlog = as_int(value);
+                  }
+                  else
+                  {
+                     unknown = true;
+                  }
+               }
+               else if (!strcmp(key, "statistics_output"))
+               {
+                  if (!strcmp(section, "pgprtdbg"))
+                  {
+                     max = strlen(value);
+                     if (max > MISC_LENGTH - 1)
+                     {
+                        max = MISC_LENGTH - 1;
+                     }
+                     memcpy(config->statistics_output, value, max);
                   }
                   else
                   {

--- a/src/libpgprtdbg/pipeline.c
+++ b/src/libpgprtdbg/pipeline.c
@@ -57,7 +57,7 @@ pipeline_client(struct ev_loop* loop, struct ev_io* watcher, int revents)
    status = pgprtdbg_read_message(wi->client_fd, &msg);
    if (likely(status == MESSAGE_STATUS_OK))
    {
-      pgprtdbg_client(wi->client_fd, wi->server_fd, msg);
+      pgprtdbg_client(wi->client_fd, wi->server_fd, msg, wi->counter);
 
       if (config->save_traffic)
       {
@@ -156,7 +156,7 @@ pipeline_server(struct ev_loop* loop, struct ev_io* watcher, int revents)
    status = pgprtdbg_read_message(wi->server_fd, &msg);
    if (likely(status == MESSAGE_STATUS_OK))
    {
-      pgprtdbg_server(wi->server_fd, wi->client_fd, msg);
+      pgprtdbg_server(wi->server_fd, wi->client_fd, msg, wi->counter);
 
       if (config->save_traffic)
       {

--- a/src/libpgprtdbg/protocol.c
+++ b/src/libpgprtdbg/protocol.c
@@ -34,6 +34,7 @@
 #include <protocol.h>
 #include <worker.h>
 #include <utils.h>
+#include <counter.h>
 
 /* system */
 #include <ev.h>
@@ -96,7 +97,7 @@ static size_t new_data_size = 0;
 static void* data = NULL;
 
 void
-pgprtdbg_client(int from, int to, struct message* msg)
+pgprtdbg_client(int from, int to, struct message* msg, struct event_counter* counter)
 {
    char* text = NULL;
 
@@ -105,6 +106,9 @@ pgprtdbg_client(int from, int to, struct message* msg)
 
    pgprtdbg_log_line("FE/Message (%d):", msg->length);
    pgprtdbg_log_mem(msg->data, msg->length);
+
+   counter->sent_messages++;
+   counter->sent_bytes += msg->length;
 
    data = pgprtdbg_data_append(data, data_size, msg->data, msg->length, &new_data_size);
    data_size = new_data_size;
@@ -198,7 +202,7 @@ done:
 }
 
 void
-pgprtdbg_server(int from, int to, struct message* msg)
+pgprtdbg_server(int from, int to, struct message* msg, struct event_counter* counter)
 {
    char* text = NULL;
 
@@ -207,6 +211,9 @@ pgprtdbg_server(int from, int to, struct message* msg)
 
    pgprtdbg_log_line("BE/Message (%d):", msg->length);
    pgprtdbg_log_mem(msg->data, msg->length);
+
+   counter->rcvd_messages++;
+   counter->rcvd_bytes += msg->length;
 
    data = pgprtdbg_data_append(data, data_size, msg->data, msg->length, &new_data_size);
    data_size = new_data_size;

--- a/src/libpgprtdbg/worker.c
+++ b/src/libpgprtdbg/worker.c
@@ -35,6 +35,7 @@
 #include <pipeline.h>
 #include <worker.h>
 #include <utils.h>
+#include <counter.h>
 
 /* system */
 #include <ev.h>
@@ -48,10 +49,11 @@ volatile int exit_code = WORKER_FAILURE;
 static void sigquit_cb(struct ev_loop* loop, ev_signal* w, int revents);
 
 void
-pgprtdbg_worker(int client_fd)
+pgprtdbg_worker(int client_fd, int client_number)
 {
    struct ev_loop* loop = NULL;
    struct ev_signal signal_watcher;
+   struct event_counter* counter;
    struct worker_io client_io;
    struct worker_io server_io;
    struct configuration* config;
@@ -67,6 +69,10 @@ pgprtdbg_worker(int client_fd)
 
    memset(&client_io, 0, sizeof(struct worker_io));
    memset(&server_io, 0, sizeof(struct worker_io));
+
+   counter = pgprtdbg_counter_get(client_number);
+   client_io.counter = counter;
+   server_io.counter = counter;
 
    for (int i = 0; i < MAX_NUMBER_OF_CONNECTIONS; i++)
    {


### PR DESCRIPTION
This commit creates counter.h and counter.c to create event counters so that it is possible to output messages statistics to the console or to a file.

It also modifies other functions and structs so it is possible to pass the event counters around.

@jesperpedersen What do you think?

I still have to add documentation.